### PR TITLE
Adding issue template for new term request

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_term_template.md
+++ b/.github/ISSUE_TEMPLATE/new_term_template.md
@@ -1,0 +1,14 @@
+---
+name: New term request
+about: A request for a new term to be added to the ontology.
+labels: new_term_request
+---
+# New term label (required)
+
+# Definition (required)
+
+# Position in the hierarchy or the parent class (required)
+
+# Synonyms
+
+# Cross-references


### PR DESCRIPTION
Closes #24 

Adds issue template for new term request. The new issue is labelled with 'new_term_request'.