### PR TITLE
Change line ending from DOS- to Unix-style.

### DIFF
--- a/source/PaNET.csv
+++ b/source/PaNET.csv
@@ -1,4 +1,4 @@
-﻿,ID,Label,Alt Label 1,Alt Label 2,Definition,Definition Source,RDF Type,Class Type,Parent IRI,Parent IRI,Parent IRI,Parent IRI,Parent IRI,Equivalent ,Equivalent ,Disjoint Classes,Individual,Property Assertions
+,ID,Label,Alt Label 1,Alt Label 2,Definition,Definition Source,RDF Type,Class Type,Parent IRI,Parent IRI,Parent IRI,Parent IRI,Parent IRI,Equivalent ,Equivalent ,Disjoint Classes,Individual,Property Assertions
 ,ID,A rdfs:label,A http://www.w3.org/2004/02/skos/core#altLabel,A http://www.w3.org/2004/02/skos/core#altLabel,A IAO:0000115,A IAO:0000119,TYPE,CLASS_TYPE,CI,CI,CI,CI,CI,EC %,EC %,DC %,TI %,I 'hasTechnique'
 ,,,,,,,,,,,,,,,,,,
 Base IRI,,http://purl.org/pan-science/PaNET/,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Motivation:

We have inconsistent line endings at the moment: the Ontology metadata file uses Unix-style line endings while the PaNET.csv file uses DOS-style line endings.  It would be better if the PaNET repository was consistent.

Moreover, Unix tools may convert DOS-style lines to Unix-style lines. This results in large diffs, making it hard to see actual changes.

Modification:

Run the `dos2unix` command on the PaNET.csv.  This results in two changes:

  * The line endings are updated from `\r\n` (`0x0d 0x0a`) to `\n` (`0x0a`)

  * The UTF BOM (a three-byte sequence at the file's beginning that is normally not visible) is removed.

Result:

More consistent choice of line ending.  Removal of potentially confusing BOM.

Closes: #128