### PR TITLE
Teach git to ignore panet-build generated output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/source/PaNET.owl
+/widoco


### PR DESCRIPTION
Motivation:

The PaNET build script generates both the PaNET ontology (`sources/PaNET.owl`) and some web-based documentation in the directory `widoco/`.  Therefore, after building PaNET, git sees these artefacts as potentiall new content and commands like `git status` show warnings about them.

Modification:

Create a `.gitignore` file to identify that these artefacts are auto-generated, so should be ignored.

Results:

git no longer warns about generated content as being untracked.

Closes: #130