### PR TITLE
Remove version information from PaNET metadata

### DIFF
--- a/source/PaNET_metadata.ttl
+++ b/source/PaNET_metadata.ttl
@@ -69,5 +69,3 @@ This project was undertaken under ExPaNDS WP3.2 (https://expands.eu/)
 The ontology is can be found here: https://github.com/ExPaNDS-eu/ExPaNDS-experimental-techniques-ontology
 
 Photon and neutron PaN ontologies developed under ExPaNDS are documented here: https://doi.org/10.5281/zenodo.4806026"^^xsd:string ;
-owl:versionInfo "1.0"^^xsd:string ;
-owl:versionInfo "First version of the Photon and Neutron Experimental Techniques (PaNET) ontology".


### PR DESCRIPTION
Motivation:

The version information in `PaNET_metadata.ttl` is out-of-date. Moreover the current concept is to use git tags to identify the version, which makes this information redundant.

The PaNET build script removes the `owl:versionInfo` statements in `PaNET_metadata.ttl` before adding the git-derived version information. Although this results in correct version information appearing in the PaNET file, the version information in `PaNET_metadata.ttl` is potentially confusing.

Modification:

Remove `owl:versionInfo` from `PaNET_metadata.ttl`.

Result:

The build process is simpler to understand, as there are no longer any statements in `PaNET_metadata.ttl` that are not copied into the final ontology.

Closes: #132