### PR TITLE
Generate reasoned version of PaNET

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.4
+      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.5
 
     steps:
       - name: Checkout repo
@@ -27,7 +27,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: PaNET
-          path: source/PaNET.owl
+          path: |
+            source/PaNET.owl
+            source/PaNET_reasoned.owl
           retention-days: 7
 
       - name: Upload documentation as artifact


### PR DESCRIPTION
Motivation:

From issue #120:
> [Support] users that want to exploit it using SPARQL queries, or
> simple python scripts. In the case of a clean Tbox the user looses all
> the inferred axioms and possibly some valuable results.

Modification:

Update build script to v0.5.  This includes support for building an additional "reasoned" version of the ontology as
`source/PaNET_reasoned.owl`.

Update the workflow to capture this additional artefact when uploading to GitHub.

Result:

We now build (and make available) both an unreasoned and a reasoned version of the ontology.

Closes: #120