### PR TITLE
Remove named individuals

### DIFF
--- a/source/PaNET.csv
+++ b/source/PaNET.csv
@@ -390,14 +390,3 @@ ID number,,,,,,,,,,,,,,,,,,
 ,http://purl.org/pan-science/PaNET/PaNET00000,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,
 ,,Create dataset instances and give them hasTechnique relationship to instances of techniques. Can then use reasoner to search for individuals based on 'hasTechnique some technique' where technique is any of the technique classes above.,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,PaNET:dataset,dataset,,,"A dataset in the domain of neutron, muon and accelerator-based light sources",,owl:Class,subclass,owl:Thing,,,,,,,,,
-,PaNET:hasTechnique,hasTechnique,,,,,owl:ObjectProperty,,,,,,,,,,,
-,PaNET:mySingleCrystalDiffractionTechnique,mySingleCrystalDiffractionTechnique,,,,,single crystal diffraction,,,,,,,,,,,
-,PaNET:my_single_crystal_x-ray_diffraction_data_123,my_single_crystal_x-ray_diffraction_data_123,,,,,dataset,,,,,,,,,,,mySingleCrystalDiffractionTechnique
-,PaNET:myHighResNeutronPowderDiffractionTechnique,myHighResNeutronPowderDiffractionTechnique,,,,,high resolution neutron powder diffraction,,,,,,,,,,,
-,PaNET:my_neutron_powder_diffraction_diffraction_data_55,my_neutron_powder_diffraction_diffraction_data_55,,,,,dataset,,,,,,,,,,,myHighResNeutronPowderDiffractionTechnique
-,PaNET:myARPEStechnique,myARPEStechnique,,,,,angle resolved photoemission spectroscopy,,,,,,,,,,,
-,PaNET:my_ARPES_data,my_ARPES_data,,,,,dataset,,,,,,,,,,,myARPEStechnique
-,PaNET:myMicrofocusX-rayAbsorptionSpectroscopyTechnique,myMicrofocusX-rayAbsorptionSpectroscopyTechnique,,,,,microfocus x-ray absorption spectroscopy,,,,,,,,,,,
-,PaNET:my_microfocus_spectrosopy_data,my_microfocus_spectrosopy_data,,,,,dataset,,,,,,,,,,,myMicrofocusX-rayAbsorptionSpectroscopyTechnique


### PR DESCRIPTION
Motivation:

PaNET contains a namespace `PaNET:` which is the empty/default namespace. This contains a number of example items (a class, an object property and several named individuals) that are meant to illustrate how PaNET may be used.

This `PaNET:` namespace is poorly documented and not part of the main purpose of PaNET (identifying experimental techniques).  These two points together risk causing confusion.

Moreover, the `PaNET:` namespace is badly defined and causes problems with newer versions of the OBO-Robot toolkit.

Modification:

The following class is removed:
    PaNET:dataset

The following objectProperty is removed:
    PaNET:hasTechnique

The following named individuals are removed:
    PaNET:myARPEStechnique
    PaNET:myHighResNeutronPowderDiffractionTechnique
    PaNET:myMicrofocusX-rayAbsorptionSpectroscopyTechnique
    PaNET:mySingleCrystalDiffractionTechnique
    PaNET:my_ARPES_data
    PaNET:my_microfocus_spectrosopy_data
    PaNET:my_neutron_powder_diffraction_diffraction_data_55
    PaNET:my_single_crystal_x-ray_diffraction_data_123

Result:

The next release of PaNET will no longer include the named individuals, allowing the ontology to focused on the job of identifying the experimental technique.

Closes: #52