### PR TITLE
Fix two validation errors in PaNET_metadata.ttl

### DIFF
--- a/source/PaNET_metadata.ttl
+++ b/source/PaNET_metadata.ttl
@@ -60,7 +60,7 @@
     ] ;
     dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
 
-    rdfs:comment "Photon and Neutron Experimental Techniques: An ontology of  techniques within the photon and neutron (PaN) domain.
+    rdfs:comment """Photon and Neutron Experimental Techniques: An ontology of  techniques within the photon and neutron (PaN) domain.
 
 Purpose
 
@@ -78,4 +78,5 @@ This project was undertaken under ExPaNDS WP3.2 (https://expands.eu/)
 
 The ontology is can be found here: https://github.com/ExPaNDS-eu/ExPaNDS-experimental-techniques-ontology
 
-Photon and neutron PaN ontologies developed under ExPaNDS are documented here: https://doi.org/10.5281/zenodo.4806026"^^xsd:string ;
+Photon and neutron PaN ontologies developed under ExPaNDS are documented here: https://doi.org/10.5281/zenodo.4806026"""^^xsd:string ;
+.


### PR DESCRIPTION
Motivation:

The Apache Jena tool `riot` discovered two problems with the current content of `PaNET_metadata.ttl`:
  * A multi-line text literal is not allowed for values contained within single quotes.
  * The set of assertions are not terminated with a dot.

Modification:

Switch string literal to use long-quote.

Add missing terminating dot.

Result:

The `PaNET_metadata.ttl` file is now valid Turtle.

Closes: #144