### PR TITLE
Add workflow job to validate PaNET_metadata.ttl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,17 @@ on:
     tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Validate PaNET_metadata.ttl
+        uses: vemonet/jena-riot-action@v3.14
+        with:
+          input: source/PaNET_metadata.ttl
+
   build:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Motivation:

Issue #144 arises from the file `sources/PaNET_metadata.ttl` not containing valid Turtle.  We wish to avoid any repetition of this problem.

Modification:

Add a new job `validate` that runs the Apache Jena's riot tool to validate RDF files.  Currently this is limited to the single file `sources/PaNET_metadata.ttl`.

Result:

The CI/CD is updated to check whether the `sources/PaNET_metadata.ttl` file is validate Turtle.