### PR TITLE
Add text declaration of files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+
+## Identify certain files as containing text.
+##
+## A text file is handled specially on OSes that have different
+## line-ending convention from Unix.  On such OSes, the checked-out file
+## is updated to follow the local line-ending convention, while the
+## reverse conversion is applied when updating the repository.  The
+## result is that text files may be edited using OS-native tools, with
+## git taking care of any discrepancy.
+
+# By default, use git's ability to guess whether a file contains text.
+* text=auto
+
+# Identify certain files as text, based on their file extension.
+*.ttl text
+*.csv text
+*.md text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## Minor enhancements and bug-fixes.
 
 - http://purl.org/pan-science/PaNET/PaNET01146:
-  
+
 Change label to 'photoemission electron microscopy' for better consistency with community usage.
-  
+
 - http://purl.org/pan-science/PaNET/PaNET01107 (inelastic small angle scattering):
 
 Fix typo in label
@@ -19,7 +19,7 @@ Remove equivalence to 'versus energy' as this wrongly classifies MAD as spectros
 No longer a subclass of 'diffraction' (which was an error).
 
 - Internal update: Add disjoint classes to Robot CSV file for easier implementation of disjoints.
-  
+
 - http://purl.org/pan-science/PaNET/PaNET01034 ('inelastic scattering') & http://purl.org/pan-science/PaNET/PaNET01020 ('elastic scattering')
 
 Now defined as being disjoint classes.


### PR DESCRIPTION
Motivation:

Operating systems have different standards for line endings.  When working collaboratively, these differences cause problems.

Modification:

Add a `.gitattributes` file to identify certain files as containing text.  These are then stored (in github) following a canonical representation (Unix or LF-ending).  The `git` command will automatically convert these text files on OSes with different line-ending conventions, which will allow editing according to OS-native convention.

The `CHANGELOG.md` file is updated to the canonical form.  Some trailing whitespace is also removed.

Result:

Greater protection against text files suffering from line-ending confusion.

Closes: #141