### PR TITLE
update panet-build to v0.6; enable ontology diff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.5
+      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.6
 
     steps:
       - name: Checkout repo
@@ -32,7 +32,7 @@ jobs:
         run: /usr/bin/git config --global --add safe.directory `pwd`
 
       - name: Build PaNET and documentation
-        run: /bin/build-panet
+        run: /bin/build-panet -d
 
       - name: Archive generated PaNET
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Motivation:

The latest version of panet-build (v0.6) adds support for showing the changes from the previous commit.  This allows us to verify the effect of the pull-request, in terms of adding or removing axioms.

Modification:

Update panet-build version to v0.6

Enable the new diff feature (`-d` command-line option).

Result:

We should now have more information about proposed changes.