### PR TITLE
Teaching git to ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /source/PaNET.owl
+/source/PaNET_reasoned.owl
 /widoco


### PR DESCRIPTION
Motivation:

Commit dfce0a0d9d added support for generating reasoned output; that is, an additional file that also includes all RDFS entailment axioms.

Unfortunately, that commit forgot to tell git to ignore the additional reasoned output file.  This means that, after building PaNET, git shows an untracked file.

Modification:

Add the missing entry in the `.gitignore` file.

Result:

git no longer reports an untracked file after building PaNET.