### PR TITLE
Teach git to ignore Mac .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /source/PaNET.owl
 /widoco
+.DS_Store


### PR DESCRIPTION
Motivation:

Macs have a habit of writing extra metadata as the file `.DS_Store`.  There's a risk that these become included in commits by mistake, where they can cause confusion and/or extend commits as the metadata is changed.

Modification:

Add `.DS_Store` to the list of files that git should ignore.

Result:

Hopefully fewer commits that include `.DS_Store` files.