### PR TITLE
Iss67 panet metadata

### DIFF
--- a/source/PaNET_metadata.ttl
+++ b/source/PaNET_metadata.ttl
@@ -7,9 +7,9 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix sdo: <http://schema.org/> .
 @prefix vann: <http://purl.org/vocab/vann/>.
-@base <http://purl.org/pan-science/PaNET/PaNET-metadata.owl> .
+@base <http://purl.org/pan-science/PaNET/PaNET.owl> .
 
-<http://purl.org/pan-science/PaNET/PaNET-metadata.owl>
+<http://purl.org/pan-science/PaNET/PaNET.owl>
   a owl:Ontology ;
   dcterms:created "2021-05-19"^^xsd:string ; 
   vann:preferredNamespaceUri <http://purl.org/pan-science/PaNET/> ; 


### PR DESCRIPTION
Motivation

Issue #67 describes some errors in the metadata source file. The issue is rather old and some details seem to have changed. I (re)describe the issue as it looks for me now:
The file source/PaNET_metadata.ttl claims to describe http://purl.org/pan-science/PaNET/PaNET-metadata.owl, however, it is actually describing http://purl.org/pan-science/PaNET/PaNET.owl.
Errors with the xml namespace are suspected

Modification

- replace http://purl.org/pan-science/PaNET/PaNET-metadata.owl by http://purl.org/pan-science/PaNET/PaNET.owl, twice
- remove unused prefixes rdf and xml (which might have caused an issue)
- (added a space to [kind of] unify person names)

Closes #67