### PR TITLE
Add mapping of PaNET and voc4cat

### DIFF
--- a/mappings/Makefile
+++ b/mappings/Makefile
@@ -1,0 +1,22 @@
+TARGETS=mapping_voc4cat.ttl
+
+all: ${TARGETS}
+
+clean:
+	rm -f ${TARGETS}
+
+%.ttl: %.csv
+	robot \
+	    template \
+	        --template mapping_voc4cat.csv \
+	        --prefix "panet: http://purl.org/pan-science/PaNET/" \
+	        --prefix "skos: http://www.w3.org/2004/02/skos/core#" \
+	        --prefix "wfl: https://www.wayforlight.eu/catalogue?Techniques=" \
+	        --prefix "voc4cat: https://w3id.org/nfdi4cat/voc4cat_" \
+	        --add-prefix "panet: http://purl.org/pan-science/PaNET/" \
+	        --add-prefix "skos: http://www.w3.org/2004/02/skos/core#" \
+	        --add-prefix "wfl: https://www.wayforlight.eu/catalogue?Techniques=" \
+	        --add-prefix "voc4cat: https://w3id.org/nfdi4cat/voc4cat_" \
+	        --output mapping_voc4cat.ttl
+	        
+.PHONY: all

--- a/mappings/mapping_voc4cat.csv
+++ b/mappings/mapping_voc4cat.csv
@@ -1,0 +1,16 @@
+ID,Label,Related Match,Close Match,Exact Match,Narrow Match,Broad Match
+ID,LABEL,AI skos:relatedMatch SPLIT=|,AI skos:closeMatch SPLIT=|,AI skos:exactMatch SPLIT=|,AI skos:narrowMatch SPLIT=|,AI skos:broadMatch SPLIT=|
+panet:PaNET01318,atomic force microscopy,,,voc4cat:0000070,,
+panet:PaNET01059,versus energy loss,,,,,voc4cat:0000068
+panet:PaNET01320,fourier transform infrared spectroscopy,,,voc4cat:0000080,,
+panet:PaNET01268,mass spectrometry,,,voc4cat:0000137,,
+panet:PaNET01050,nuclear resonance,,,,,voc4cat:0000073
+panet:PaNET01111,luminescence,,,,voc4cat:0000074,
+panet:PaNET01195,raman spectroscopy,,,voc4cat:0000069,,
+panet:PaNET01293,scanning photoelectron microscopy,,,,,voc4cat:0000075
+panet:PaNET01145,electron microscopy,,,,voc4cat:0000078,
+panet:PaNET01130,UV VUV spectroscopy,,,,voc4cat:0000079,
+panet:PaNET01007,UV visible photon probe,,voc4cat:0000079,,,
+panet:PaNET01216,x-ray diffraction,,,voc4cat:0000077,,
+panet:PaNET01177,x-ray fluorescence,,,voc4cat:0000067,,
+panet:PaNET01204,x-ray photoelectron spectroscopy,,,voc4cat:0000076,,


### PR DESCRIPTION
Motivation

Mappings allow to connect different vocabularies or listed terms with each other. voc4cat is an outcome of a NFDI initiative (https://github.com/nfdi4cat/voc4cat-tool). voc4cat is a vocabulary of catalytic terms that overlap with PaNET terms. Connecting the techniques of voc4cat with PaNET terms will enable different applications in the future.

Modification

I used the skos terms relatedMatch, closeMatch, exactMatch, narrowMatch, and broadMatch to connect a PaNET term (IRI and name) to a term in WFL. 

Result

Future applications can now connect PaNET terms to the functionalities and database content of WFL.

Closes #191.