### PR TITLE
Update GitHub CI/CD to use panet-build v0.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.7
+      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.9
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Motivation:

Add support for `PaNET:` and `:` as prefixes for IRIs.

Modification:

Version bump to v0.9

Result:

PaNET builds with current CSV source.