### PR TITLE
Update CI/CD to use panet-build to v0.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.9
+      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.10
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Motivation:

This version of panet-build brings two changes:

    Update robot to v1.9.8
    Omit unused support for empty prefix

Modification:

Update CI/CD to use v0.10 of the build container

Result:

Reduced errors, better reporting.