### PR TITLE
Update CI/CD to use panet-build v0.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.10
+      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.11
 
     steps:
       - name: Checkout repo
@@ -44,10 +44,9 @@ jobs:
           retention-days: 7
 
       - name: Upload documentation as artifact
-        id: widoco-docs
         uses: actions/upload-pages-artifact@v3
         with:
-          path: widoco/
+          path: site/
           retention-days: 7
 
   deploy:
@@ -67,5 +66,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
-        id: widoco-docs
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /source/PaNET.owl
 /source/PaNET_reasoned.owl
 /widoco
+/site
 .DS_Store


### PR DESCRIPTION
Motivation:

Panet Build v0.11 brings a number of benfits:

  - runs a custom version of widoco that includes showing the skos:altLabels.

  - build a site directory, which merges the static docs directory and the auto-generated widoco directories.

Modification:

Update CI/CD workflow to
  - use v0.11 container of panet-build.

  - use the `site/` directory as the documentation source.

  - remove redundant `id` values.

Teach git not to track the `site/` directory.

Result:

We now deploy the `docs/` directory as our website, while keeping the widoco documentation.