### PR TITLE
Update build procedure to create widoko documentation for releases.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.11
+      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.12
 
     steps:
       - name: Checkout repo
@@ -32,7 +32,7 @@ jobs:
         run: /usr/bin/git config --global --add safe.directory `pwd`
 
       - name: Build PaNET and documentation
-        run: /bin/build-panet -d
+        run: /bin/build-panet -d -s
 
       - name: Archive generated PaNET
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Motivation:

We would like to make available documentation for all PaNET releases.

In addition, the latest release should have a permanent link, in order to allow someone to refer to the latest release without knowing which release that is.

Modification:

Upgrade to 0.12 of build script.  This brings the option of downloading

Enable the option of building the site documentation.

Result:

The CI/CD now provides documentation for all released versions of PaNET.