### PR TITLE
Fix broken link on webpage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
                 <h1>Documentation</h1>
                 <ul class="nav-list">
                     <li><a href="index.html" class="nav-link-selected" data-section="scope">Scope of PaNET</a></li>
-                    <li><a href="https://expands-eu.github.io/ExPaNDS-experimental-techniques-ontology/index-en.html" class="nav-link" data-section="scope">Browse PaNET</a></li>
+                    <li><a href="https://pan-ontologies.github.io/PaNET/index-en.html" class="nav-link" data-section="scope">Browse PaNET</a></li>
                     <li><a href="applications.html" class="nav-link" data-section="applications">Applications</a></li>
                     <li><a href="workflow.html" class="nav-link" data-section="git-workflow">Git Workflow</a></li>
                     <li><a href="std_op_proc.html" class="nav-link" data-section="procedures">Standard Operating Procedures</a></li>


### PR DESCRIPTION
### Motviation

After migrating the git repo to the project pan-ontologies, the link to the documentation (widoco) is outdated.

### Modification

The link for "Browse PaNET" was updated to https://pan-ontologies.github.io/PaNET/index-en.html

### Related Issues
Contributes to #358