### PR TITLE
Add git conflict finder to CI/CD pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,14 @@ jobs:
         with:
           input: source/PaNET_metadata.ttl
 
+        # Robot `template` doesn't fail on git conflict markers, see:
+        #   https://github.com/ontodev/robot/issues/1279
+        #
+        # In order to catch these problems, we test for such markers
+        # explicitly.
+      - name: Merge Conflict finder
+        uses: olivernybroe/action-conflict-finder@v4.0
+
   build:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Motivation:

Robot's template command doesn't fail on git conflict markers, so we need another way of catching commits that mistaken include such markers.

Modification:

Include an additional check during the `validate` job of the build, to check that we don't have any such conflict markers.

Result:

Mistakenly including conflict markers in a commit now cause the CI/CD build to fail.

Closes: #378

<!-- 
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR addresses.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Motivation
<!-- Description of the current situation and why it is unsatisfactory. -->

# Modification
<!-- Description of the change -->

# Result
<!-- Description of the result -->

# Related Issues
<!-- 
Link to the related issue, using the format "#123"; 
"closes #123" will automatically close issue #123 
-->
