### PR TITLE
Resolve conflict from techniques identified by beamline characteristics

### DIFF
--- a/source/PaNET.csv
+++ b/source/PaNET.csv
@@ -13,18 +13,11 @@ ID number,,,,,,,,,,,,,,,,,,,,,,,,
 100,http://purl.org/pan-science/PaNET/PaNET00100,photon probe technique,,,"A technique using photons, which are elementary particles that are quanta of the electromagnetic field. Photons cover (list sorted by increasing wavelength): gamma radiation, x radiation, UV light, visible light, infrared light, microwaves, radiowaves and long radio waves. The different types are characterized by wavelength (nm), frequency (GHz), or energy (eV).",https://en.wikipedia.org/wiki/Photon,owl:Class,,,,,,,,('definedbyprobe' some 'photon'),,,,,,,,,
 101,http://purl.org/pan-science/PaNET/PaNET00101,neutron probe technique,,,,,owl:Class,,,,,,,,('definedbyprobe' some 'neutron'),,,,,,,,,
 102,http://purl.org/pan-science/PaNET/PaNET00102,muon probe technique,,,,,owl:Class,,,,,,,,('definedbyprobe' some 'muon'),,,,,,,,,
-<<<<<<< HEAD
 ,,,,,,,,,,,,,,,,,,,,,,,,
 103,http://purl.org/pan-science/PaNET/PaNET00103,solid probe,,,,,owl:Class,,,,,,,,('definedbycharacteristic' some PaNET:PaNET2011003),,,,,,,,,
 104,http://purl.org/pan-science/PaNET/PaNET00104,scanning probe,,,,,owl:Class,,,,,,,,('definedbycharacteristic' some PaNET:PaNET2011004),,,,,,,,,
 105,http://purl.org/pan-science/PaNET/PaNET00105,pulsed probe,,,A technique for which a pulsed probe is essential,,owl:Class,,,,,,,,('definedbycharacteristic' some PaNET:PaNET2011005),,,,,,,,,
 106,http://purl.org/pan-science/PaNET/PaNET00106,microfocused probe,,,using a beam with dimensions in the micrometre range;may or may not result in a map (2D); see obtain high resolution map,,owl:Class,,,,,,,,('definedbycharacteristic' some PaNET:PaNET2011006),,,,,,,,,
-=======
-103,http://purl.org/pan-science/PaNET/PaNET00103,solid probe,,,,,owl:Class,,,,,,,,('definedbyprobe' some PaNET:PaNET2011003),,,,,,,,,
-104,http://purl.org/pan-science/PaNET/PaNET00104,scanning probe,,,,,owl:Class,,,,,,,,('definedbyprobe' some PaNET:PaNET2011004),,,,,,,,,
-105,http://purl.org/pan-science/PaNET/PaNET00105,pulsed probe,,,A technique for which a pulsed probe is essential,,owl:Class,,,,,,,,('definedbyprobe' some PaNET:PaNET2011005),,,,,,,,,
-106,http://purl.org/pan-science/PaNET/PaNET00106,microfocused probe,,,,,owl:Class,,,,,,,,('definedbyprobe' some PaNET:PaNET2011006),,,,,,,,,
->>>>>>> c15b766 (Clarifying distinction between photon probes and photon techniques)
 ,,,,,,,,,,,,,,,,,,,,,,,,
 200,http://purl.org/pan-science/PaNET/PaNET00200,scattering technique,,,Any phenomenon where a particle of the same type as the probe is emitted,,owl:Class,,,,,,,,('definedbyprocess' some 'scattering'),,,,,,,,,
 201,http://purl.org/pan-science/PaNET/PaNET00201,emission technique,,,Independent of probe; classed also as scattering if the probe and emitted particles are of the same type; disjoint with elastic scattering,,owl:Class,,,,,,,,('definedbyprocess' some 'emission'),,,,,,,,,


### PR DESCRIPTION
Motivation:

Seeminly, at some point, there was a conflict between two commits: one that renamed the collection of techniques defined by a probe (`photon probe` --> `photon probe technique`) and a commit that introduced the "beam characteristic" specifier.

This conflict was unfortunately not resolved before the change being committed and merged into the `master` branch, resulting in the git conflict markers being committed as part of the CSV file.

Modification:

Resolve the conflict in favour of the HEAD branch, which uses the `definebycharacteristic` definition of these techniques, instead of the earlier `definedbyprobe` definition.

Result:

Conflict has been resolved, removing archaic definition lines.

Closes: #376

<!-- 
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR addresses.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Motivation
<!-- Description of the current situation and why it is unsatisfactory. -->

# Modification
<!-- Description of the change -->

# Result
<!-- Description of the result -->

# Related Issues
<!-- 
Link to the related issue, using the format "#123"; 
"closes #123" will automatically close issue #123 
-->
