### PR TITLE
Update CI/CD to use panet-build to v0.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.12
+      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.13
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Motivation:

This version of panet-build brings two changes:

    Update github API endpoint in response to PaNET repo being moved.

Modification:

Update CI/CD to use v0.13 of the build container

Result:

Generation of website works again

<!-- 
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR addresses.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Motivation
<!-- Description of the current situation and why it is unsatisfactory. -->

# Modification
<!-- Description of the change -->

# Result
<!-- Description of the result -->

# Related Issues
<!-- 
Link to the related issue, using the format "#123"; 
"closes #123" will automatically close issue #123 
-->
