### PR TITLE
Update references to old widoco location to point to new location

### DIFF
--- a/mappings/Mappings.md
+++ b/mappings/Mappings.md
@@ -56,7 +56,7 @@ The template includes some extra information in angle brackets `<>` as well as a
 # mapping_set_id: mapping_WFL_PaNET_v1.0,,,,,,,,,
 # mapping_set_version: '2025-11-12',,,,,,,,,
 # object_source: https://www.wayforlight.eu/technique/,,,,,,,,,
-# subject_source: https://expands-eu.github.io/ExPaNDS-experimental-techniques-ontology/index-en.html,,,,,,,,,
+# subject_source: https://pan-ontologies.github.io/PaNET/latest/index-en.html,,,,,,,,,
 # ,,,,,,,,,
 subject_id,subject_label,predicate_id,object_id,object_label,mapping_justification,author_id,object_source_version,mapping_date,confidence
 panet:PaNET00410,medical application,skos:exactMatch,wfl:1419,Medical application,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,10.17,2025-11-12,1

--- a/mappings/mapping_WFL.csv
+++ b/mappings/mapping_WFL.csv
@@ -13,7 +13,7 @@
 # mapping_set_id: mapping_WFL_PaNET_v1.0,,,,,,,,,
 # mapping_set_version: '2025-11-12',,,,,,,,,
 # object_source: https://www.wayforlight.eu/technique/,,,,,,,,,
-# subject_source: https://expands-eu.github.io/ExPaNDS-experimental-techniques-ontology/index-en.html,,,,,,,,,
+# subject_source: https://pan-ontologies.github.io/PaNET/latest/index-en.html,,,,,,,,,
 # ,,,,,,,,,
 subject_id,subject_label,predicate_id,object_id,object_label,mapping_justification,author_id,object_source_version,mapping_date,confidence
 panet:PaNET00410,medical application,skos:exactMatch,wfl:1419,Medical application,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,10.17,2025-11-12,1

--- a/mappings/mapping_template.csv
+++ b/mappings/mapping_template.csv
@@ -13,7 +13,7 @@
 # mapping_set_id: <mapping_??_PaNET_v1.0>,,,,,,,,,
 # mapping_set_version: <date of last edit>,,,,,,,,,
 # object_source: <your custom >,,,,,,,,,
-# subject_source: https://expands-eu.github.io/ExPaNDS-experimental-techniques-ontology/index-en.html,,,,,,,,,
+# subject_source: https://pan-ontologies.github.io/PaNET/latest/index-en.html,,,,,,,,,
 # ,,,,,,,,,
 subject_id,subject_label,predicate_id,object_id,object_label,mapping_justification,author_id,object_source_version,mapping_date,confidence
 panet:PaNET00410,medical application,skos:exactMatch,wfl:1419,Medical application,semapv:ManualMappingCuration,orcid:<your orcid as digits and dashes>,<version>,<date in ISO 8601 format>,"<number in [0,..,1]>"


### PR DESCRIPTION
There are several places where the URLs currently point to the old location of the widoco documentation.  With the move to pan-ontologies, these URLs now yield 404 status codes.
