### PR TITLE
Add contact information to webpage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -28,3 +28,25 @@
         <li><strong>the technique distinguishes itself from another technique by an essential dependency on some well-defined sample interaction.</strong> A laser pump-probe is an example of such an interaction.</li>
     </ul>
 </div>
+
+<div>
+    <h2>Get in Contact</h2>
+    <h3>Regular Meetings</h3>
+    <ul>
+        <li>every Thursday 10:00 CEST</li>
+        <li><a href="https://indico.desy.de/category/1163/">details</a></li>
+    </ul>
+
+    <h3>Subscribe to our Mailing Lists</h3>
+    <p>There are two mailing lists for different purposes available. The <strong>Announcement List</strong> will provide detailed information on releases and will only be sent once or twice a year. It is dedicated to service providers that use PaNET. The <strong>Maintenance List</strong> is used to invite to the weekly meetings and announce the agendas. It can also be used to initiate discussions and highlight open issues.</p>
+
+    <ul>
+        <li>Go to the public page of the mailing list (<a href="https://lists.desy.de/sympa/subscribe/panet-announce">Announcement</a>, <a href="https://lists.desy.de/sympa/subscribe/panet-maintenance">Maintenance</a>).</li>
+        <li>Enter your email address and name.</li>
+        <li>Press the blue button "I subscribe to list panet-announce".</li>
+        <li>The page updates and you need to confirm (blue button).</li>
+        <li>You receive a mail by SYMPA with the title "DESY Mailing lists services" and including a link. Click it.</li>
+        <li>A German text asks you to confirm your subscription by clicking the button "Bestätigen" while the "Abonnieren" is marked with a checkmark.</li>
+        <li>You receive a welcome mail by panet-announce-request@desy.de or panet-maintenance-request@desy.de</li>
+    </ul>
+</div>


### PR DESCRIPTION
### Motivation

A visitor to our website would not easily find the ways of keeping in touch with changes to PaNET.

In particular, there doesn't seem to be information on how someone could subscribe to the announcements mailing list.

### Modification

The index page now contains the same contact information as the README.md:
- information to the weekly meetings and indico page
- guidelines for subscribing to the mailing lists

### Result

It is now easier to get in touch witht he PaNET team.

### Related Issues 
closes #406
