### PR TITLE
Improve structure of webpage

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,0 +1,26 @@
+# called items with site.data.navigation
+- name: Home
+  link: "/index.html"
+  description: General information on PaNET
+  subnav:
+    - name: Scope of PaNET
+      link: "/index.html"
+    - name: Applications
+      link: "/applications.html"
+
+- name: Browse
+  link: "https://pan-ontologies.github.io/PaNET/index-en.html"
+  description: Ontology Specification page
+
+- name: Documentation
+  link: "/std_op_proc.html"
+  description: Documentation of PaNET
+  subnav:
+    - name: Standard Operating Procedure
+      link: "/std_op_proc.html"
+    - name: Git Workflow
+      link: "/workflow.html"
+    - name: Build the Robot Environment
+      link: "/build.html"
+    - name: Make a Release
+      link: "/release.html"

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,0 +1,30 @@
+# called items with site.data.navigation
+- name: Home
+  link: "/"
+  description: General information on PaNET
+  subnav:
+    - name: Scope of PaNET
+      link: "/"
+    - name: Applications
+      link: "/applications.html"
+      description: Applications, terminology registries, mappings and projects related to PaNET
+
+- name: Browse
+  link: "https://pan-ontologies.github.io/PaNET/index-en.html"
+  description: Ontology Specification Page
+
+- name: Documentation
+  link: "/std_op_proc.html"
+  description: Documentation of PaNET
+  subnav:
+    - name: Standard Operating Procedure
+      link: "/std_op_proc.html"
+    - name: Git Workflow
+      link: "/workflow.html"
+      description: Guideline for contributions
+    - name: Build the Robot Environment
+      link: "/build.html"
+      description: Instructions to handle the robot ontology verification software
+    - name: Make a Release
+      link: "/release.html"
+      description: Guidelines for realeases (for Maintainers).

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -1,12 +1,30 @@
 <nav id="navigation">
-    <h1>Documentation</h1>
     <ul class="nav-list">
-        <li><a href="{{ 'index.html' | relative-url }}" class="nav-link" data-section="scope">Scope of PaNET</a></li>
-        <li><a href="https://pan-ontologies.github.io/PaNET/index-en.html" class="nav-link" data-section="scope">Browse PaNET</a></li>
-        <li><a href="{{ 'applications.html' | relative-url }}" class="nav-link" data-section="applications">Applications</a></li>
-        <li><a href="{{ 'workflow.html' | relative-url }}" class="nav-link" data-section="git-workflow">Git Workflow</a></li>
-        <li><a href="{{ 'std_op_proc.html' | relative-url }}" class="nav-link" data-section="procedures">Standard Operating Procedures</a></li>
-        <li><a href="{{ 'build.html' | relative-url }}" class="nav-link" data-section="environment">Build the Environment</a></li>
-        <li><a href="{{ 'release.html' | relative-url }}" class="nav-link" data-section="release">Make a Release</a></li>
-    </ul>
+    {% for item in site.data.navigation %}
+      {% if item.subnav %}
+        <li class="nav-1st">
+          <a href="{{ item.link | relative_url }}" {% if page.url == item.link %} class="focus" {% endif %} class="nav-link">
+            {{ item.name }}
+          </a>
+          <div class="nav-2nd">
+            <ul>
+              {% for subitem in item.subnav %}
+                <li>
+                  <a href="{{ subitem.link | relative_url }}" {% if page.url == subitem.link %} class="focus" {% endif %} class="nav-link">
+                    {{ subitem.name }}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </li>
+      {% else %}
+        <li>
+          <a href="{{ item.link | relative_url }}" {% if page.url == item.link %} class="focus" {% endif %} class="nav-link">
+            {{ item.name }}
+          </a>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
 </nav>

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -1,12 +1,22 @@
 <nav id="navigation">
-    <h1>Documentation</h1>
     <ul class="nav-list">
-        <li><a href="{{ 'index.html' | relative-url }}" class="nav-link" data-section="scope">Scope of PaNET</a></li>
-        <li><a href="https://pan-ontologies.github.io/PaNET/index-en.html" class="nav-link" data-section="scope">Browse PaNET</a></li>
-        <li><a href="{{ 'applications.html' | relative-url }}" class="nav-link" data-section="applications">Applications</a></li>
-        <li><a href="{{ 'workflow.html' | relative-url }}" class="nav-link" data-section="git-workflow">Git Workflow</a></li>
-        <li><a href="{{ 'std_op_proc.html' | relative-url }}" class="nav-link" data-section="procedures">Standard Operating Procedures</a></li>
-        <li><a href="{{ 'build.html' | relative-url }}" class="nav-link" data-section="environment">Build the Environment</a></li>
-        <li><a href="{{ 'release.html' | relative-url }}" class="nav-link" data-section="release">Make a Release</a></li>
-    </ul>
+    {% for item in site.data.navigation %}
+      <li class="nav-1st">
+        <a href="{{ item.link | relative_url }}" title="{{ item.description }}" {% if page.url == item.link %} class="focus" {% endif %} class="nav-link">
+          {{ item.name }}
+        </a>
+        <div class="nav-2nd">
+          <ul>
+            {% for subitem in item.subnav %}
+              <li>
+                <a href="{{ subitem.link | relative_url }}" title="{{ subitem.description }}" {% if page.url == subitem.link %} class="focus" {% endif %} class="nav-link">
+                  {{ subitem.name }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </li>
+    {% endfor %}
+  </ul>
 </nav>

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -145,17 +145,9 @@ body {
   left: 0;
 }
 
-#navigation h1 {
-  color: var(--panet-dark-blue);
-  font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  font-size: 2rem;
-  margin-bottom: 25px;
-  border-bottom: 4px solid var(--panet-pink);
-  padding-bottom: 15px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
+/*
+  NAVIGATION
+*/
 
 .nav-list {
   list-style: none;
@@ -167,16 +159,21 @@ body {
   margin-bottom: 8px;
 }
 
+.nav-list ul { /* removes all bullet points in navigation bar*/
+  list-style: none;
+  padding-left: 20px;
+}
+
 .nav-link {
   display: block;
-  padding: 15px 20px;
+  padding: 10px;
   color: var(--panet-black);
   text-decoration: none;
   border-radius: 8px;
   transition: all 0.3s ease;
   font-size: 1.2rem;
   border-left: 4px solid transparent;
-  font-weight: 500;
+  font-weight: bold;
   font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 }
 
@@ -191,8 +188,21 @@ body {
   background: linear-gradient(135deg, var(--panet-purple) 0%, var(--panet-dark-blue) 100%);
   color: white;
   border-left-color: var(--panet-pink);
-  font-weight: 600;
+  font-weight: bold;
   box-shadow: 0 2px 8px rgba(101, 109, 177, 0.3);
+}
+
+.focus {
+  display: block;
+  padding: 10px;
+  color: var(--panet-pink);
+  text-decoration: none;
+  border-radius: 8px;
+  transition: all 0.3s ease;
+  font-size: 1.2rem;
+  border-left: 4px solid transparent;
+  font-weight: bold;
+  font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 }
 
 .nav-link-selected {
@@ -202,7 +212,7 @@ body {
   text-decoration: none;
   border-radius: 8px;
   transition: all 0.3s ease;
-  font-size: 1.2rem;
+  font-size: 2.4rem;/*1.2rem;*/
   border-left: 4px solid transparent;
   font-weight: 500;
   font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;


### PR DESCRIPTION
### Motivation

The current structure of the homepage feels crowded and arbitrary. I suggest to update it and group the topics.

### Modification

We now have three top level topics: Home, Browse, and Documentation. Home includes the 'Scope of PaNET' and 'Applications'. Browse forwards to the 'Ontology Specification' page (widoco). Documentation includes 'Standard Operation Procedure', 'Git Workflow', 'Build the Robot Environment', and 'Make a Release'.

Additionally, the navigation layout has been improved and is now dynamic (based on the _data/navigation.yml).

### Result

The structure of the webpage is clearer and more intuitive.

### Related Issues

Closes #363