### PR TITLE
Update pipeline to also run on merge requests from fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ '*' ]
     tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
+  pull_request: # on pull requests from fork
 
 jobs:
   validate:


### PR DESCRIPTION
### Motivation

Currently, the pipeline only runs after a merge request from a fork is being merged into main. The pipeline does not run when somebody pushes from a fork. This means that all checks and the creation of the webpage are only active after approval. However, the checks would be very valuable for the reviewers as a quality indicator.

### Modification

The pipeline now has the flag 'on: pull_request', which is supposed to be triggered when somebody makes a push from a fork.

### Result

The checks are run already before the review. Additionally, the webpages are also provided as an artifact for inspection before the review.

### Related Issues
contributes to #435