### PR TITLE
Correct paths in head.html and header.html

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -5,8 +5,8 @@
     <title>PANET: Photon and Neutron Experimental Techniques</title>
 
     <! -- style -->
-    <link rel="stylesheet" type="text/css" href="{{ 'assets/css/custom.css' | relative_url }}">
+    <link rel="stylesheet" type="text/css" href="assets/css/custom.css">
 
     <! -- favicons et. al. courtesy of realfavicongenerator.net -->
-    <link rel="icon" href="{{ 'assets/images/favicon.svg' | realtive_url }}" type="image/svg">
+    <link rel="icon" href="assets/images/favicon.svg" type="image/svg">
 </head>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,6 +1,6 @@
 <header id="fixed-header">
     <div class="header-content">
-        <img id="panet_logo" alt="PaNET Logo" src="{{ 'assets/images/panet_logo_bg.svg' | realtive_url }}" alt="PANET Logo" class="logo">
+        <img id="panet_logo" alt="PaNET Logo" src="assets/images/panet_logo_bg.svg" alt="PANET Logo" class="logo">
         <h1 class="main-title">PANET: Photon and Neutron Experimental Techniques</h1>
     </div>
 </header>


### PR DESCRIPTION
### Motivation

The paths to the assets (logo, favicon and css file) are currently set incorrectly in head.html and header.html.
Using `relative_url` produces a path with `PaNET` included, which produces pages that do not find the respective assets.
Additionally, a typo broke the `relative_link` for logo and favicon in such a favorable way that the actually path was valid.

### Modification

The path was changed from `"{{ 'assets/xyz.svg' | relative_url }}"` to `"assets/xyz.svg"`.

### Result

- more concise links
- correct paths in produced artifacts

### Related Issues

Contributes to #435
