### PR TITLE
Correct spelling of nanografting in IUPAC mapping

### DIFF
--- a/mappings/mapping_IUPAC.csv
+++ b/mappings/mapping_IUPAC.csv
@@ -87,7 +87,7 @@ Panet:PaNET01268,mass spectrometry,skos:narrowMatch,goldbook:12419,Fourier-trans
 Panet:PaNET01195,raman spectroscopy,skos:narrowMatch,goldbook:08606,Fourier-transform Raman spectroscopy,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 Panet:PaNET01320,fourier transform infrared spectroscopy,skos:broadMatch,goldbook:FT07382,Fourier-transform spectroscopy ,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 panet:PaNET01097,gamma spectroscopy,skos:exactMatch,goldbook:08728,gamma-ray spectrometry,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,0.99
-panet:PaNET01233,polymer micro and nanograftin,skos:broadMatch,goldbook:GT07138,grafting,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
+panet:PaNET01233,polymer micro and nanografting,skos:broadMatch,goldbook:GT07138,grafting,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 panet:PaNET01098,grazing incidence diffraction,skos:relatedMatch,goldbook:08608 ,grazing incidence ,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 panet:PaNET01162,grazing incidence small angle x-ray scattering,skos:exactMatch,goldbook:09199,grazing-incidence small-angle X-ray scattering analysis,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 panet:PaNET01059,versus energy loss,skos:narrowMatch,goldbook:R05236 ,high resolution energy loss spectroscopy,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1

--- a/mappings/mapping_IUPAC.csv
+++ b/mappings/mapping_IUPAC.csv
@@ -10,7 +10,7 @@
 # license: https://creativecommons.org/licenses/by/4.0/,,,,,,,,,
 # mapping_set_description: Manually curated alignment of the PaNET ontology with the IUPAC goldbook.,,,,,,,,,
 #   Intended to be used for ontological analysis.,,,,,,,,,
-# mapping_set_id: mapping_goldbook_PaNET_v1.0,,,,,,,,,
+# mapping_set_id: mapping_goldbook_PaNET_v1.0.1,,,,,,,,,
 # mapping_set_version: '2025-11-13',,,,,,,,,
 # object_source: https://goldbook.iupac.org/,,,,,,,,,
 # subject_source: https://pan-ontologies.github.io/PaNET/latest/index-en.html,,,,,,,,,
@@ -87,7 +87,7 @@ Panet:PaNET01268,mass spectrometry,skos:narrowMatch,goldbook:12419,Fourier-trans
 Panet:PaNET01195,raman spectroscopy,skos:narrowMatch,goldbook:08606,Fourier-transform Raman spectroscopy,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 Panet:PaNET01320,fourier transform infrared spectroscopy,skos:broadMatch,goldbook:FT07382,Fourier-transform spectroscopy ,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 panet:PaNET01097,gamma spectroscopy,skos:exactMatch,goldbook:08728,gamma-ray spectrometry,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,0.99
-panet:PaNET01233,polymer micro and nanograftin,skos:broadMatch,goldbook:GT07138,grafting,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
+panet:PaNET01233,polymer micro and nanografting,skos:broadMatch,goldbook:GT07138,grafting,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 panet:PaNET01098,grazing incidence diffraction,skos:relatedMatch,goldbook:08608 ,grazing incidence ,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 panet:PaNET01162,grazing incidence small angle x-ray scattering,skos:exactMatch,goldbook:09199,grazing-incidence small-angle X-ray scattering analysis,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1
 panet:PaNET01059,versus energy loss,skos:narrowMatch,goldbook:R05236 ,high resolution energy loss spectroscopy,semapv:ManualMappingCuration,orcid:0000-0002-5850-4469,Online version 5.0.0,2025-10-28,1


### PR DESCRIPTION
### Motivation

The spelling of 'polymer micro and nanografting' is wrong in the mapping with IUPAC and should be corrected.

### Modification

The spelling was updated from polymer 'micro and nanograftin' to 'polymer micro and nanografting'.
The versioning will be updated.

### Result

The mapping has been improved. 'micro and nanografting' will now actually be connected to IUPAC goldbook.

### Related Issues

closes #428