### PR TITLE
Extend application webpage

### DIFF
--- a/docs/applications.html
+++ b/docs/applications.html
@@ -29,6 +29,11 @@
             the local metadata catalogues and will modify queries on the fly in such a way that 
             conditions referring to a technique will be expanded to include all child techniques 
             in PaNET. </li>
+        <li><strong>Targeted search for training materials</strong> using 
+            <a href="https://pan-training.eu/">PaN Training</a></li>
+        <li><strong>Find relations between techniques</strong> by querying a 
+            <a href="https://www.w3.org/TR/sparql11-query/">sparql</a> endpoint, e.g. 
+            at <a href="https://metadata.desy.de/qlever">DESY</a></li>
     </ul>
 
     <h2>Terminology Registries</h2>
@@ -39,6 +44,7 @@
             Bioportal</a></li>
         <li><a href="https://terminology.tib.eu/ts/ontologies?and=false&sortedBy=title&page=1&size=10">
             TIB Terminology Service</a></li>
+        <li><a href="https://fairsharing.org/5410">FAIRsharing</a></li>
     </ul>
 
     <h2>Mappings</h2>
@@ -47,10 +53,10 @@
         reuse and extend existing use-cases and applications.</p>
     <ul class="md-itemization">
         <li><a href="https://github.com/nfdi4cat/voc4cat">voc4cat</a> (established)</li>
-        <li><a href="https://www.wayforlight.eu/">Way for Light</a> (ongoing)</li>
-        <li><a href="https://dictionary.iucr.org/">IUCr dictionary</a> (ongoing)</li>
-        <li><a href="https://goldbook.iupac.org/">IUPAC gold book</a> (ongoing)</li>
-        <li><a href="https://connect.helmholtz-imaging.de/application/">Helmholtz Imaging</a> (ongoing)</li>
+        <li><a href="https://www.wayforlight.eu/">Way for Light</a> (established)</li>
+        <li><a href="https://dictionary.iucr.org/">IUCr dictionary</a> (established)</li>
+        <li><a href="https://goldbook.iupac.org/">IUPAC gold book</a> (established)</li>
+        <li><a href="https://connect.helmholtz-imaging.de/application/">Helmholtz Imaging</a> (established)</li>
         <li><a href="https://physh.org/">PhySH</a> (ongoing)</li>
         <li><a href="https://www.wikidata.org/wiki/Wikidata:Main_Page">wikidata</a> (foreseen)</li>
     </ul>


### PR DESCRIPTION
### Motivation

Since the creation of the application webpage, we found and created more applications of PaNET.

### Modification

- added sparql endpoint, example DESY
- updated information on mappings
- added PaN Training
- added FAIRsharing as Terminology Registry

### Result

Better overview of potential applications.

### Related Issues

Closes #447 and #364