### PR TITLE
Simplify the documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Code of Conduct
 
 This code of conduct applies to the maintainers and contributors alike.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+../CODE_OF_CONDUCT.md

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Guidlines for Creating and Reviewing the PaNET Webpages
 
 The PaNET webpages are supposed to give an overview of the scope and application of PaNET. 

--- a/docs/Mappings.md
+++ b/docs/Mappings.md
@@ -1,0 +1,1 @@
+../mappings/Mappings.md

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -13,7 +13,7 @@
   link: "https://pan-ontologies.github.io/PaNET/index-en.html"
   description: Ontology Specification Page
 
-- name: Documentation
+- name: Getting Started
   link: "/std_op_proc.html"
   description: Documentation of PaNET
   subnav:
@@ -22,9 +22,23 @@
     - name: Git Workflow
       link: "/workflow.html"
       description: Guideline for contributions
+    - name: Code of Conduct
+      link: "/CODE_OF_CONDUCT.html"
+      description: Guidelines for ethical behaviour, respectful interactions, and community standards.
+
+- name: Technical References
+  link: "/build.html"
+  description: Instructions to handle the robot ontology verification software
+  subnav:
     - name: Build the Robot Environment
       link: "/build.html"
       description: Instructions to handle the robot ontology verification software
+    - name: Mappings
+      link: "/Mappings.html"
+      description: Guidelines for creating and maintaining relations to other semantic artifacts.
+    - name: Guidelines for the Documentation Pages
+      link: "/DOCS.html"
+      description: Guidelines for creating and maintaining the webpage.
     - name: Make a Release
       link: "/release.html"
       description: Guidelines for realeases (for Maintainers).

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -56,6 +56,11 @@ body {
   color: var(--panet-black);
 }
 
+.highlight {
+  max-width: 800px;
+  overflow-x: auto;
+}
+
 /* Wrapper adjustments */
 #wrapper {
   display: flex;
@@ -373,6 +378,7 @@ body {
     width: 100%;
     position: static;
     max-height: none;
+    min-width: 0;
     border-left: none;
     border-bottom: 1px solid var(--panet-border-grey);
   }

--- a/mappings/Mappings.md
+++ b/mappings/Mappings.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Mappings
 
 A mapping connects the terms or concepts listed in different semantic artifacts. A semantic artifact can be a 


### PR DESCRIPTION
### Motivation

We currently have several sources of information distributed in PaNET, which also means twice the effort for maintenance, e.g. code of conduct, contributing.

### Modification

Jekyll can 'convert' md files into html.
Precondition:
- header consisting of two lines with '---'
- md file in /docs (e.g. softlink)
- include in navigation

By creating a softlink from the main files (e.g. CODE_OF_CONDUCT.md in root) in /docs, the files are provided as html pages.

The files are/will be (WIP) included in the navigation structure by updating the /docs/_data/navigation.yml.

### Result

Reduction of maintenance work

### Related Issues

closes #373
