### PR TITLE
Add a build phase that validates generated PaNET with LintedData

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,24 @@ jobs:
           path: site/
           retention-days: 7
 
+  validate-panet:
+    needs: build-panet
+    runs-on: ubuntu-latest
+    container: dlrdw/linteddata:3.0.0
+    steps:
+      - name: Download freshly built PaNET
+        uses: actions/download-artifact@v4
+        with:
+          name: PaNET
+
+      - name: Check with LintedData
+        run: LintedData source/PaNET_reasoned.owl --markdown linted-data.md --junit linted-data.xml
+
+      - name: Add LintedData results to job summary
+        if: ${{ !cancelled() }}
+        run: head -q -c1024k linted-data.md >> $GITHUB_STEP_SUMMARY
+
+
   build-webpage:
     runs-on: ubuntu-latest
     needs: build-panet


### PR DESCRIPTION
Motivation:

Use available tools to check for common problems with PaNET.

Modification:

Add build step that runs the LintedData image on the generated output.

Result:

Better Q/A process for PaNET output.

<!-- 
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR addresses.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Motivation
<!-- Description of the current situation and why it is unsatisfactory. -->

# Modification
<!-- Description of the change -->

# Result
<!-- Description of the result -->

# Related Issues
<!-- 
Link to the related issue, using the format "#123"; 
"closes #123" will automatically close issue #123 
-->
