### PR TITLE
Add a build phase that validates generated PaNET with LintedData

### DIFF
--- a/.github/linteddata.yaml
+++ b/.github/linteddata.yaml
@@ -1,0 +1,17 @@
+checks:
+  RDF:
+    LeadingOrTrailingSpaceCheck: false
+    NamespaceHijackingCheck: false
+    SeparatorOmittedInNamespaceCheck: false
+  RDFS:
+    UnconnectedClassCheck: false
+    VersionIriExistenceCheck: false
+    LeadingOrTrailingSpaceCheck: false
+    MissingDescriptionCheck: false
+    MissingLabelCheck: false
+  OWL:
+    FileExtensionInIriCheck: false
+    OntologyIriOboConformanceCheck: false
+    SynonymsAsClassesCheck: false
+    UnconnectedClassCheck: false
+    VersionIriExistenceCheck: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,33 @@ jobs:
           path: site/
           retention-days: 7
 
+  validate-panet:
+    needs: build-panet
+    runs-on: ubuntu-latest
+    container: dlrdw/linteddata:3.0.0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download freshly built PaNET
+        uses: actions/download-artifact@v4
+        with:
+          name: PaNET
+
+      - name: Check with LintedData
+        run: LintedData PaNET_reasoned.owl --markdown linted-data.md --junit linted-data.xml --config .github/linteddata.yaml
+
+      - name: Add LintedData results to job summary
+        if: ${{ !cancelled() }}
+        run: head -q -c1024k linted-data.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: (!cancelled())
+        with:
+            files: |
+                  linted-data.xml
+
   build-webpage:
     runs-on: ubuntu-latest
     needs: build-panet


### PR DESCRIPTION
Motivation:

Use available tools to check for common problems with PaNET.

Modification:

Add build step that runs the LintedData image on the generated output. The commit also includes an initial configuration that suppresses some known issues with PaNET.  Issue #462 will resolve these suppressed checks, allowing more correct output from PaNET:

https://github.com/pan-ontologies/PaNET/issues/462

Result:

Better Q/A process for PaNET output.

Closes: #409

<!-- 
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR addresses.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Motivation
<!-- Description of the current situation and why it is unsatisfactory. -->

# Modification
<!-- Description of the change -->

# Result
<!-- Description of the result -->

# Related Issues
<!-- 
Link to the related issue, using the format "#123"; 
"closes #123" will automatically close issue #123 
-->
