### PR TITLE
Repair deploy pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
   deploy:
     # From naming convention on above tag selection, tags
     # only trigger the workflow if they are releases.
-    #if: ${{ github.ref_type == 'tag' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: build-webpage
 
     permissions:


### PR DESCRIPTION
### Motivation

Currently, the pipeline is setup in such a way that it always fails in the last step: "deploy" with the following error message

> Branch "refs/pull/481/merge" is not allowed to deploy to github-pages
> due to environment protection rules.

The protection rules have been set up to only allow releases to make these changes. However, this protection is now causing the pipeline to fail every time (except for rare releases), which leaves an untidy/unprofessional impression.

### Modification

Re-activating if-condition in the deploy pipeline.

### Result

Pipeline not failing at every run.

### Related Issues

closes #483