### PR TITLE
Update technique definition on index page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,11 +7,13 @@
     <ul class="md-itemization">
         <li><strong>experimental physical probe</strong></li>
 
-        <li><strong>experimental probe</strong></li>
+        <li><strong>experimental physical process</strong></li>
 
         <li><strong>functional dependence</strong></li>
 
         <li><strong>purpose</strong></li>
+
+        <li><strong>beam characteristic</strong></li>
     </ul>
 
     <img id="panet_scheme" src="assets/images/PaNET_scheme.svg" alt="PaNET scheme. Users of a PaN facility have a specific scientific question about a sample (the purpose of the experiment). To address this query, they select an appropriate technique, characterized by the physical probe (e.g. x-rays) and the interaction (process) it induces within the sample. The experiment can tehn be executed under varied external conditions (dependence of e.g. temperature).">


### PR DESCRIPTION
### Motivation

The technique definition on the index page does not contain process, but probe twice. Additionally, the new category beam characteristic is missing.

### Modification

Updated the list to contain 'experimental physcial process' and 'beam characteristic'.

### Related Issues

closes #446