### PR TITLE
Add explicit permission to in validate-panet job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,10 @@ jobs:
     needs: build-panet
     runs-on: ubuntu-latest
     container: dlrdw/linteddata:3.0.0
+    permissions:
+      checks: write
+      contents: read       # Required to checkout code
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
The `validate-panet` job uses the `EnricoMi/publish-unit-test-result` action to publish the JUnit output from running LintedData validation of the OBO-Robot-built output.

Publishing results requires write access to the `checks` resource, which is currently missing.

This patch adds this authorisation specifically for the `validate-panet` job.

<!-- 
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR addresses.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Motivation
<!-- Description of the current situation and why it is unsatisfactory. -->

# Modification
<!-- Description of the change -->

# Result
<!-- Description of the result -->

# Related Issues
<!-- 
Link to the related issue, using the format "#123"; 
"closes #123" will automatically close issue #123 
-->
