### PR TITLE
Add test configuration for checking w3id.org and purl.org

### DIFF
--- a/pid-tests/README.md
+++ b/pid-tests/README.md
@@ -1,0 +1,18 @@
+# PID checks
+
+This directory contains tests for checking PaNET PIDs are functioning correct.
+
+The following tests are provided:
+
+|---|---|
+|File| Target service |
+|---|---|
+| `check-w3id.json` | Redirections in `https://w3id.org/` |
+|`check-purl.json` | Redirections in `https://purl.org/` |
+|---|---|
+
+To run the tests, you need the `test-redirection` script from [w3id-tester repo](https://github.com/pan-ontologies/w3id-tester).
+
+Example command to check w3id.org: `../../w3id-tester/test-redirection -c check-w3c.json`
+
+Example command to check purl.org: `./test-redirection -c check-purl.json`.

--- a/pid-tests/check-purl.json
+++ b/pid-tests/check-purl.json
@@ -1,0 +1,44 @@
+[
+    {
+        "name": "PaNET: latest release",
+        "description": "A constant link to the latest version of PaNET (unreasoned)",
+        "source_url": "https://purl.org/pan-science/PaNET/PaNET.owl",
+        "expected_status": 302,
+        "expected_location": "https://github.com/pan-ontologies/PaNET/releases/latest/download/PaNET.owl"
+    },
+    {
+        "name": "PaNET: link for mapping",
+        "description": "A (suspect?) support for a mapping",
+        "source_url": "https://purl.org/pan-science/integration/PaN-mapping",
+        "expected_status": 302,
+        "expected_location": "http://www.purl.org/pan-science/integration/PaN-mapping/0.1"
+    },
+    {
+        "name": "ESRFET: link to deliverable",
+        "description": "A (suspect?) link for ESRFET URL",
+        "source_url": "https://purl.org/pan-science/ESRFET",
+        "expected_status": 302,
+        "expected_location": "https://github.com/pan-ontologies/esrf-ontologies/tree/oscars-deliverable-31-12-2024"
+    },
+    {
+        "name": "PaNET: documentation",
+        "description": "Documentation of the latest version of PaNET.",
+        "source_url": "https://purl.org/pan-science/PaNET/",
+        "expected_status": 302,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/index-en.html"
+    },
+    {
+        "name": "PaNET: documentation anchor",
+        "description": "An anchor in documentation of the latest version of PaNET.",
+        "source_url": "https://purl.org/pan-science/PaNET/foo",
+        "expected_status": 302,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/index-en.html#foo"
+    },
+    {
+        "name": "PaNET: document for IRI",
+        "description": "An anchor in documentation of a PaNET IRI.",
+        "source_url": "https://purl.org/pan-science/PaNET/PaNET0001",
+        "expected_status": 302,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/index-en.html#PaNET0001"
+    }
+]

--- a/pid-tests/check-w3id.json
+++ b/pid-tests/check-w3id.json
@@ -1,0 +1,178 @@
+[
+    {
+        "name": "w3id canary",
+        "description": "An example redirection, maintained by w3id, that we use to verify the test framework itself.",
+        "source_url": "/examples/simple/",
+        "expected_status": 302,
+        "expected_location": "https://example.com/"
+    },
+
+    {
+        "name": "PaNET latest: download RDF/XML",
+        "description": "Download the latest RDF/XML version of PaNET.",
+        "source_url": "/PaN/PaNET/latest/PaNET.owl",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/latest/ontology.owl"
+    },
+    {
+        "name": "PaNET latest: download RDF/XML (reasoned)",
+        "description": "Download the latest RDF/XML version of PaNET that includes inferred axions.",
+        "source_url": "/PaN/PaNET/latest/PaNET_reasoned.owl",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/latest/ontology_reasoned.owl"
+    },
+    {
+        "name": "PaNET latest: download Turtle",
+        "description": "Download the latest Turtle version of PaNET.",
+        "source_url": "/PaN/PaNET/latest/PaNET.ttl",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/latest/ontology.ttl"
+    },
+    {
+        "name": "PaNET latest: download N3",
+        "description": "Download the latest Notation3 version of PaNET.",
+        "source_url": "/PaN/PaNET/latest/PaNET.n3",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/latest/ontology.n3"
+    },
+    {
+        "name": "PaNET latest: download JSON-LD",
+        "description": "Download the latest JSON Linked Data version of PaNET.",
+        "source_url": "/PaN/PaNET/latest/PaNET.jsonld",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/latest/ontology.jsonld"
+    },
+
+    {
+        "name": "PaNET latest: docs",
+        "description": "The documentation for the latest release of PaNET",
+        "source_url": "/PaN/PaNET",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/index-en.html"
+    },
+    {
+        "name": "PaNET latest: docs with slash",
+        "description": "The documentation for the latest release of PaNET, with trailing slash",
+        "source_url": "/PaN/PaNET/",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/index-en.html"
+    },
+
+    {
+        "name": "PaNET latest: IRI, RDF/XML",
+        "description": "The RDF/XML description of an IRI within the latest release of PaNET.",
+        "source_url": "/PaN/PaNET#PaNET01134",
+        "accept": "application/rdf+xml",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/latest/ontology.owl"
+    },
+    {
+        "name": "PaNET latest: IRI, Turtle",
+        "description": "The Turtle description of an IRI within the latest release of PaNET.",
+        "source_url": "/PaN/PaNET#PaNET01134",
+        "accept": "text/turtle",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/latest/ontology.ttl"
+    },
+    {
+        "name": "PaNET latest: IRI, N3",
+        "description": "The Notation3 description of an IRI within the latest release of PaNET.",
+        "source_url": "/PaN/PaNET#PaNET01134",
+        "accept": "text/n3",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/latest/ontology.n3"
+    },
+    {
+        "name": "PaNET latest: IRI, JSON-LD",
+        "description": "The JSON Linked Data description of an IRI within the latest release of PaNET.",
+        "source_url": "/PaN/PaNET#PaNET01134",
+        "accept": "application/ld+json",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/latest/ontology.jsonld"
+    },
+
+
+    {
+        "name": "PaNET version: download RDF/XML",
+        "description": "Download an RDF/XML description of PaNET v1.2.0.",
+        "source_url": "/PaN/PaNET/1.2.0/PaNET.owl",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/ontology.owl"
+    },
+    {
+        "name": "PaNET version: download RDF/XML (reasoned)",
+        "description": "Download an RDF/XML description of PaNET v1.2.0 the includes inferred axions.",
+        "source_url": "/PaN/PaNET/1.2.0/PaNET_reasoned.owl",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/ontology_reasoned.owl"
+    },
+    {
+        "name": "PaNET version: download Turtle",
+        "description": "Download a Turtle description of PaNET v1.2.0.",
+        "source_url": "/PaN/PaNET/1.2.0/PaNET.ttl",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/ontology.ttl"
+    },
+    {
+        "name": "PaNET version: download N3",
+        "description": "Download a Notation3 description of PaNET v1.2.0.",
+        "source_url": "/PaN/PaNET/1.2.0/PaNET.n3",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/ontology.n3"
+    },
+    {
+        "name": "PaNET version: download JSON-LD",
+        "description": "Download a JSON Linked Data description of PaNET v1.2.0.",
+        "source_url": "/PaN/PaNET/1.2.0/PaNET.jsonld",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/ontology.jsonld"
+    },
+
+    {
+        "name": "PaNET version: docs",
+        "description": "The documentation for PaNET v1.2.0",
+        "source_url": "/PaN/PaNET/1.2.0",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/index-en.html"
+    },
+    {
+        "name": "PaNET version: docs, with slash",
+        "description": "The documentation for PaNET v1.2.0, with trailing slash",
+        "source_url": "/PaN/PaNET/1.2.0/",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/index-en.html"
+    },
+
+    {
+        "name": "PaNET version: IRI, RDF/XML",
+        "description": "The RDF/XML description of an IRI within PaNET v1.2.0.",
+        "source_url": "/PaN/PaNET/1.2.0#PaNET01134",
+        "accept": "application/rdf+xml",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/ontology.owl"
+    },
+    {
+        "name": "PaNET version: IRI, Turtle",
+        "description": "The Turtle description of an IRI within PaNET v1.2.0.",
+        "source_url": "/PaN/PaNET/1.2.0#PaNET01134",
+        "accept": "text/turtle",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/ontology.ttl"
+    },
+    {
+        "name": "PaNET version: IRI, N3",
+        "description": "The Notation3 description of an IRI within PaNET v1.2.0.",
+        "source_url": "/PaN/PaNET/1.2.0#PaNET01134",
+        "accept": "text/n3",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/ontology.n3"
+    },
+    {
+        "name": "PaNET version: IRI, JSON-LD",
+        "description": "The JSON Linked Data description of an IRI within PaNET v1.2.0.",
+        "source_url": "/PaN/PaNET/1.2.0#PaNET01134",
+        "accept": "application/ld+json",
+        "expected_status": 307,
+        "expected_location": "https://pan-ontologies.github.io/PaNET/1.2.0/ontology.jsonld"
+    }
+]


### PR DESCRIPTION
Motivation:

It is important that switchboard services, like purl.org and w3id.org are configured correctly.  We would benefit from having a way to test the redirections are working.

Modification:

Add two configurations the `test-redirection` script.  This script is available from the
[w3id-tester](https://github.com/pan-ontologies/w3id-tester) repo.

Note: the w3id.org checks currently fail because we haven't established the correct rules, yet.

Result:

We now have a way to ensure correct behaviour of our redirection services.

<!-- 
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR addresses.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Motivation
<!-- Description of the current situation and why it is unsatisfactory. -->

# Modification
<!-- Description of the change -->

# Result
<!-- Description of the result -->

# Related Issues
<!-- 
Link to the related issue, using the format "#123"; 
"closes #123" will automatically close issue #123 
-->
